### PR TITLE
[FIX] switch zeit now to Vercel Now for Gatsby deployment

### DIFF
--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -2,7 +2,7 @@
 title: Deploying to Now
 ---
 
-[ZEIT Now](https://zeit.co/now) is a [cloud platform for serverless deployment](https://zeit.co/docs/v2/getting-started/introduction-to-now/) that you can use to deploy your Gatsby projects and [alias them](https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/) to your personal domain or a free `.now.sh` suffixed URL.
+[ZEIT Now](https://vercel.com/now) is a [cloud platform for serverless deployment](https://vercel.com/docs/v2/getting-started/introduction-to-now/) that you can use to deploy your Gatsby projects and [alias them](https://vercel.com/docs/v2/domains-and-aliases/aliasing-a-deployment/) to your personal domain or a free `.now.sh` suffixed URL.
 
 This guide will show you how to get started in a few quick steps:
 
@@ -22,7 +22,7 @@ npx gatsby new <your project name>
 
 ## Step 2: Getting Now
 
-You can use Now by installing [Now Desktop](https://zeit.co/docs/v2/getting-started/installation/#now-desktop), which also installs Now CLI and keeps it up-to-date automatically.
+You can use Now by installing [Now Desktop](https://vercel.com/docs/v2/getting-started/installation/#now-desktop), which also installs Now CLI and keeps it up-to-date automatically.
 
 To install Now CLI quickly with npm, use the following:
 
@@ -50,9 +50,9 @@ With Now CLI installed, we can go on to deploy our previously setup Gatsby proje
 
 This `now.json` file will allow us to do several things, specifically:
 
-- Use the [latest Now 2.0 version](https://zeit.co/blog/now-2) of [the platform](https://zeit.co/docs/v2/platform/overview/)
+- Use the [latest Now 2.0 version](https://vercel.com/blog/now-2) of [the platform](https://zeit.co/docs/v2/platform/overview/)
 - Set the project name to `my-gatsby-project`
-- Use the [@now/static-build builder](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/) to take the `package.json` file as an entrypoint and use the `public` directory as our content directory
+- Use the [@now/static-build builder](https://vercel.com/docs/v2/deployments/official-builders/static-build-now-static-build/) to take the `package.json` file as an entrypoint and use the `public` directory as our content directory
 
 The final step is to add a script to the `package.json` which will build our application:
 
@@ -77,4 +77,4 @@ That's all! Your application will now deploy, and you will receive a link simila
 
 ## References:
 
-- [Deploying Gatsby with Now](https://zeit.co/examples/gatsby/)
+- [Deploying Gatsby with Now](https://vercel.com/examples/gatsby/)


### PR DESCRIPTION
- Zeit just rebranded to now and this PR changes the deployment guidelines for deploying Gatsby to `Vercel Now`
- Now still remains Now but ZEIT is no longer zeit but `Vercel` as of today

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
